### PR TITLE
Fix: respond_to_missing? should expect more than one argument

### DIFF
--- a/lib/better_content_security_policy/content_security_policy.rb
+++ b/lib/better_content_security_policy/content_security_policy.rb
@@ -65,8 +65,8 @@ module BetterContentSecurityPolicy
       @directives[directive]
     end
 
-    def respond_to_missing?(directive)
-      valid_directive?(directive)
+    def respond_to_missing?(directive, *)
+      valid_directive?(directive) || super
     end
 
     # Converts sources from our Ruby DSL (camelcase) into proper Content-Security-Policy sources.

--- a/lib/better_content_security_policy/content_security_policy.rb
+++ b/lib/better_content_security_policy/content_security_policy.rb
@@ -12,15 +12,21 @@ module BetterContentSecurityPolicy
       default-src
       font-src
       form-action
+      frame-ancestors
       frame-src
       img-src
       manifest-src
       media-src
-      navigate-to
       object-src
       prefetch-src
+      require-trusted-types-for
       script-src
+      script-src-attr
+      script-src-elem
       style-src
+      style-src-attr
+      style-src-elem
+      trusted-types
       worker-src
     ].freeze
 
@@ -31,6 +37,8 @@ module BetterContentSecurityPolicy
       http
       https
       mediastream
+      ws
+      wss
     ].freeze
 
     QUOTED_SOURCES = %w[
@@ -39,7 +47,10 @@ module BetterContentSecurityPolicy
       unsafe-eval
       unsafe-hashes
       unsafe-inline
-      wasm-unsafe-eval
+      allow-duplicates
+      report-sample
+      script
+      strict-dynamic
     ].freeze
 
     attr_accessor :directives, :report_uri, :report_only


### PR DESCRIPTION
Sometimes respond_to_missing? will be called with more than one argument. In our case, an rspec test produced the error:
```
Failures:

  1) As::UpcController#show assigns @upc
     Failure/Error: message = "#{matcher.__send__(failure_message_method)}#{message ? " #{message}" : ""}"
     
     ArgumentError:
       wrong number of arguments (given 2, expected 1)
     # /usr/local/bundle/gems/better_content_security_policy-0.1.3/lib/better_content_security_policy/content_security_policy.rb:68:in `respond_to_missing?'
     # ./spec/controllers/as/upc_controller_spec.rb:16:in `block (3 levels) in <top (required)>'
```

It is a simple test expecting a variable assignment in the controller, for a json-only API:
```
  expect(assigns(@upc)).to eq('upc' => new_upc)
```
 
Some Googling revealed a few articles that recommend `respond_to_missing?(method_name, include_private = false)`, or with `*` as the second argument, and to call `super`. The [Ruby API](https://apidock.com/ruby/v2_5_5/Object/respond_to_missing%3F) seems to have up to 3 arguments, so I'm going with [Marc André's recommendation](https://blog.marc-andre.ca/2010/11/15/methodmissing-politely/) and using `*` in this PR.

Once patched, a second issue came up: the gem was adding `"content_security_policy" => #<BetterContentSecurityPolicy::ContentSecurityPolicy:0x0000aaaae9e2a218 @directives={}>` to the JSON response, also causing our rspec test to fail. Since CSP only applies to HTML requests, I updated our `after_action` filters with:
```
  after_action :set_content_security_policy_header, if: -> { request.format.html? }
```

Perhaps an additional change to the gem should be made to ignore non-HTML requests? Or maybe you want to leave it as an excercise for the user, but in that case, I recommend updating the README to add the conditional for apps that have more than just HTML requests. :)

Thanks for publishing this gem -- it will be very useful for us! 🙏

Update: I added another commit to my fork, to update the DIRECTIVES and MAPPINGS to match the latest [Ruby on Rails source](https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/http/content_security_policy.rb), which has been updated to support [CSP 3](https://w3c.github.io/webappsec-csp/).